### PR TITLE
Modify Compilation.py to use olddefconfig

### DIFF
--- a/source/syzdirect/Runner/Compilation.py
+++ b/source/syzdirect/Runner/Compilation.py
@@ -81,9 +81,9 @@ exec $CLANG "$@"
             f.writelines([f"{c}=n\n" for c in DisabledConfigs])
             f.writelines("\nCONFIG_KCOV=y\n")
 
-        
-        
-        compile_command = f"cd {Config.getSrcDirByCase(caseIdx)} && git checkout -- scripts/Makefile.kcov && make clean && make mrproper && yes | make CC={Config.EmitScriptPath} O={caseBCDir} oldconfig && make CC=\'{Config.EmitScriptPath}\' O={caseBCDir} -j{Config.CPUNum}"
+
+
+        compile_command = f"cd {Config.getSrcDirByCase(caseIdx)} && git checkout -- scripts/Makefile.kcov && make clean && make mrproper && make CC={Config.EmitScriptPath} O={caseBCDir} olddefconfig && make CC=\'{Config.EmitScriptPath}\' O={caseBCDir} -j{Config.CPUNum}"
         # print(Config.ExecuteCMD(compile_command))
         os.system(compile_command)
         if IsCompilationSuccessfulByCase(caseBCDir):


### PR DESCRIPTION
Hi there! Thanks for open-sourcing.

This pull request addresses an issue I ran into when running the second step, `prepare_kernel_bitcode`. As certain kernel configuration options may ask for numeric values, responding to those kernel configuration questions with "yes" will result in a loop:
![image](https://github.com/seclab-fudan/SyzDirect/assets/17863082/d5431291-e5c1-4f8e-b0c7-3e1ebffa85e5)


To fix this bug, I changed the command called by Compilation.py to use `olddefconfig` instead of `oldconfig`. This is the expected formatting for building the kernel when [automatically setting new symbols to default values](https://www.kernel.org/doc/Documentation/admin-guide/README.rst) is necessary.